### PR TITLE
Improved configuration module for easier mixing of command line arguments with configuration files

### DIFF
--- a/framework_core.py
+++ b/framework_core.py
@@ -27,13 +27,29 @@ class Framework:
     self.modules = {}
     # Load Core Extended Functionality
     self.log      = Logging(self)
+    self.files    = Files(self)
     self.config   = Config(self)
     self.interact = Interact(self)
-    self.files    = Files(self)
+    
+    
+
+    # Core Configuration Shortcuts
+    self.core_path = self.files.getPath(os.path.dirname(os.path.abspath(__file__)))
+    self.app_name = self.getAppName()
+    #self.log.print(self.app_name)
+
+    # Initialisation
+    self.config.parseArgumentParser()
 
     self.log.debug(['Core is done with loading:', '* core;', '* logging;', '* configuration;', '* interaction.'])
     
     
+  ## Context management
+  def getAppName(self):
+    return self.files.getFile(sys.argv[0]).stem
+  def getCorePath(self):
+    return self.files.getPath(os.path.dirname(os.path.abspath(__file__)))
+  
   ## Module management
   ### getModule
   #   @description returns the loaded instance of a module


### PR DESCRIPTION
in /framework/conf templates can be added that allow for modular configuration.
Configuration from cli arguments (via argparse) as well as the configuration files are combined.

As suggested in #3 --conf can now be used to load a configuration template.